### PR TITLE
fix(@schematics/angular): ensure 'none' is excluded when other aiConfig tools are selected

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -60,6 +60,10 @@ export default function (options: NgNewOptions): Rule {
     zoneless: options.zoneless,
   };
 
+  if (options.aiConfig?.includes('none') && options.aiConfig.length > 1) {
+    options.aiConfig = options.aiConfig.filter(t => t !== 'none');
+  }
+
   return chain([
     mergeWith(
       apply(empty(), [


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When running ng new, selecting None together with another AI tool (e.g., Cursor, Gemini) causes the CLI to pass both values into the ai-config schematic.
This produces a validation error:

`Schematic input does not validate against the Schema: {"tool":["none","cursor"]}
Errors:
  Data path "/tool" must NOT have more than 1 items.`

Issue Number: #30987

## What is the new behavior?

- None is now treated as mutually exclusive.
- If None is selected along with any other AI tool, it is automatically removed before schema validation.
- This prevents validation errors and aligns with user expectations.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This update improves the UX of ng new by ensuring that None cannot conflict with other AI tool selections.
A unit test was added to verify that None is ignored when combined with another tool.